### PR TITLE
changed bg of example cards

### DIFF
--- a/src/screens/ComponentScreen/index.tsx
+++ b/src/screens/ComponentScreen/index.tsx
@@ -39,7 +39,7 @@ export function Examples({
           {component.components.map((element: any, index: number) => (
             <Box
               shadow={1}
-              bg={useColorModeValue("white", "blueGray.600")}
+              bg={useColorModeValue("white", "blueGray.800")}
               my={2}
               mx={3}
               borderRadius={16}


### PR DESCRIPTION
Input and other form related components are not showing property in dark mode due to same shade of their outline and background-color of cards.